### PR TITLE
fix(CloudModel): tau_max under population inversion (#18)

### DIFF
--- a/src/spectra/Function/SlabModel/CloudModel.py
+++ b/src/spectra/Function/SlabModel/CloudModel.py
@@ -8,6 +8,9 @@
 # 0.1.2
 #    2023/07/04   u.k.   when Aji equals to 0, set Src to 0 to avoid the zero division warning
 #    2025/07/07   j.n.   add line_emissivity and line_absorption
+# 0.1.3
+#    2026/05/09   u.k.   take abs(tau).max() so tau_max is meaningful under
+#                        population inversion (negative tau)
 # -------------------------------------------------------------------------------
 
 import numpy as _numpy
@@ -79,7 +82,10 @@ def SE_to_slab_0D_(
 
         # store value
         arr_w0[k] = Line["w0"][k]
-        arr_tau_max[k] = tau[:].max()
+        # abs() handles population inversion: alp0 < 0 when Bji*nj > Bij*ni,
+        # which makes tau negative; .max() on a negative array returns the
+        # least-negative value, masking the strongest |tau|.
+        arr_tau_max[k] = _numpy.abs(tau[:]).max()
         arr_Ibar[k] = Ibar
         arr_prof_1D[i1:i2] = prof[:]
         arr_tau_1D[i1:i2] = tau[:]

--- a/src/spectra/Struct/Container/CloudModel.py
+++ b/src/spectra/Struct/Container/CloudModel.py
@@ -6,6 +6,8 @@
 #    2021/05/18   u.k.   spectra-re
 #    2022/07/20   k.i.   add Src, tau_1D
 #    2025/07/07   j.n.   add line_emissivity, line_absorption
+# 0.1.1
+#    2026/05/09   u.k.   clarify tau_max docstring: max |tau| (handles population inversion)
 # -------------------------------------------------------------------------------
 
 from dataclasses import dataclass as _dataclass
@@ -21,7 +23,7 @@ class CloudModel_Container:
     """
 
     w0: T_ARRAY  # 1d, (nLine,) wavelength, [cm]
-    tau_max: T_ARRAY  # 1d, (nLine,), maximum optical depth, [-]
+    tau_max: T_ARRAY  # 1d, (nLine,), max |optical depth| per line (abs handles population inversion), [-]
     Ibar: T_ARRAY  # 1d, (nLine,), intensity profile integrated over wavelength, [erg/cm^2/Sr/s]
     Src: T_ARRAY  # 1d, (nLine,), source function, [erg/cm^2/Sr/s]
     tau_1D: T_ARRAY  # 1d, (sum_of_line_wavelength_mesh,), optical thickness profile, [-]

--- a/tests/regression/test_reg_e2e_CloudModel.py
+++ b/tests/regression/test_reg_e2e_CloudModel.py
@@ -1,5 +1,7 @@
 """End-to-end regression tests for Cloud Model pipeline"""
 
+import numpy as _numpy
+
 from spectra.Function import SlabModel
 from spectra.Function.SEquil import SELib
 from spectra.ImportAll import *
@@ -22,3 +24,47 @@ class TestHydrogenCloudModel:
         assert_close(Cloud_con.w0, ref["E2E.H_CloudModel.w0"], rtol=1e-8)
         assert_close(Cloud_con.tau_max, ref["E2E.H_CloudModel.tau_max"], rtol=1e-8)
         assert_close(Cloud_con.Ibar, ref["E2E.H_CloudModel.Ibar"], rtol=1e-8)
+
+    def test_slab_0D_population_inversion(self):
+        """Lock in the abs() semantics of `tau_max` under population inversion.
+
+        Issue #18: when `n_upper > n_lower` (per-degeneracy), `alp0 < 0` and
+        `tau` becomes negative. Plain `tau.max()` then returns the least-negative
+        value, masking the strongest |tau|. The fix takes `|tau|.max()`.
+
+        Synthetic setup (not physically self-consistent — only `n_SE` is mutated;
+        absorb_prof_1d / Line_mesh_idxs come from the proper SE pass and stay
+        valid because they don't depend on populations).
+        """
+        conf_path = str(CFG._ROOT_DIR / "data/conf/H.conf")
+        atom, wMesh, _ = Atom.init_Atom_(conf_path, is_hydrogen=True)
+
+        atmos = Atmosphere.Atmosphere0D(Nh=1.0e12, Ne=1.0e11, Te=7.0e3, Vd=0.0, Vt=5.0e5)
+        radiation = Radiation.init_Radiation_()
+        SE_con, _ = SELib.cal_SE_with_Nh_Te_(atom, atmos, wMesh, radiation, None)
+
+        # Force inversion on line 0 by swapping J/I populations. After the swap
+        # n_upper >> n_lower (in thermal H I the lower level dominates), giving
+        # Bji*nj > Bij*ni regardless of degeneracy weights.
+        j0 = int(atom.Line["idxJ"][0])
+        i0 = int(atom.Line["idxI"][0])
+        SE_con.n_SE[j0], SE_con.n_SE[i0] = SE_con.n_SE[i0], SE_con.n_SE[j0]
+
+        # exp(-tau) overflows when |tau| is large negative (synthetic extreme,
+        # not a real-world concern). prof_1D is irrelevant for this test.
+        with _numpy.errstate(over="ignore"):
+            Cloud_con = SlabModel.SE_to_slab_0D_(atom, atmos, SE_con, depth=1.0e3 * 1.0e5)
+
+        # Sanity: line 0 actually went negative.
+        i1, i2 = int(Cloud_con.Line_mesh_idxs[0, 0]), int(Cloud_con.Line_mesh_idxs[0, 1])
+        assert _numpy.any(Cloud_con.tau_1D[i1:i2] < 0), "expected negative tau on inverted line 0"
+
+        # Contract: tau_max[k] == max(|tau_1D[i1:i2]|) for every line, signed or not.
+        # Without abs() in the implementation, this would fail on line 0 (where
+        # tau.max() picks the least-negative value, not the largest magnitude).
+        for k in range(atom.nLine):
+            i1, i2 = int(Cloud_con.Line_mesh_idxs[k, 0]), int(Cloud_con.Line_mesh_idxs[k, 1])
+            expected = _numpy.abs(Cloud_con.tau_1D[i1:i2]).max()
+            assert_close(Cloud_con.tau_max[k], expected, rtol=1e-12)
+
+        assert _numpy.all(Cloud_con.tau_max >= 0.0)


### PR DESCRIPTION
Closes #18.

## Phase 1 — fix the calculation

`SE_to_slab_0D_` computed `arr_tau_max[k] = tau[:].max()`. When the line is in population inversion (`n_upper > n_lower` per degeneracy), the absorption coefficient

```
alp0 = h*nu / (4π) * (Bij*ni - Bji*nj) * N_ele
```

turns negative, so the slice `tau = depth * alp0[k] * absorb_prof_1d[i1:i2]` is negative element-wise. `.max()` on an all-negative array picks the **least-negative** value (closest to 0), which silently hides the strongest |tau|.

Change to `_numpy.abs(tau[:]).max()`. Bit-exact noop on `tau ≥ 0`, correct under inversion. Field name `tau_max` kept (per issue).

Touched:
- `Function/SlabModel/CloudModel.py` — calculation site, inline why-comment, changelog 0.1.3
- `Struct/Container/CloudModel.py` — field docstring (`max |optical depth|`), changelog 0.1.1

## Phase 2 — lock the semantics with a regression test

`test_slab_0D_population_inversion`: run the standard H I SE pass, swap `n_SE[idxJ[0]]` ↔ `n_SE[idxI[0]]` so line 0 has `nj >> ni`, then call `SE_to_slab_0D_`. Assertions:

1. `tau_1D[i1:i2]` of line 0 has at least one negative value (sanity).
2. `tau_max[k] == |tau_1D[i1:i2]|.max()` for every line — the contract this PR establishes.
3. `tau_max ≥ 0`.

Reverting Phase 1 makes assertion 2 fail on line 0. `numpy.errstate(over="ignore")` wraps the call because `exp(-tau)` overflows on the synthetic extreme; `prof_1D` is irrelevant to this test.

## Verification

- `pytest tests/regression/`: 262/262 (was 261, +1 new).
- `pytest -W error tests/regression/test_reg_e2e_CloudModel.py`: clean.