### PR TITLE
feat(Atom): add nBoundLevel field for bound-state count

### DIFF
--- a/src/spectra/Struct/Atom.py
+++ b/src/spectra/Struct/Atom.py
@@ -74,7 +74,8 @@ class Atom:
     Mass: T_FLOAT
     Abun: T_FLOAT
 
-    nLevel: T_INT
+    nLevel: T_INT  # total levels, bound + continuum
+    nBoundLevel: T_INT  # bound levels only (excludes the continuum level)
     nLine: T_INT
     nCont: T_INT
     nTran: T_INT
@@ -143,6 +144,7 @@ def init_Atom_(conf_path: T_STR, is_hydrogen: T_BOOL = False) -> T_TUPLE[Atom, T
     # nTran nLine nCont
     # --------------------
     nLine, nCont, nTran, _has_continuum = _AtomIO.nLine_nCont_nTran_(Level["stage"])
+    nBoundLevel = nLevel - 1 if _has_continuum else nLevel
     # if not _has_continuum:
     #    raise ValueError("Currently we don't support Atomic Model without comtinuum.")
 
@@ -235,6 +237,7 @@ def init_Atom_(conf_path: T_STR, is_hydrogen: T_BOOL = False) -> T_TUPLE[Atom, T
         Mass=Mass,
         Abun=Abun,
         nLevel=nLevel,
+        nBoundLevel=nBoundLevel,
         nLine=nLine,
         nCont=nCont,
         nTran=nTran,
@@ -344,6 +347,7 @@ def init_theoretical_hydrogen_atom_(
 
     # counts and CTJ/index mapping tables
     nLine, nCont, nTran, _has_continuum = _AtomIO.nLine_nCont_nTran_(Level["stage"])
+    nBoundLevel = nLevel - 1 if _has_continuum else nLevel
     Line_idx_table, Line_ctj_table, Cont_idx_table, Cont_ctj_table = _AtomIO.prepare_idx_ctj_mapping_(
         Level_info_table, Level["stage"], Level["isGround"], nLine, nCont
     )
@@ -414,6 +418,7 @@ def init_theoretical_hydrogen_atom_(
         Mass=Mass,
         Abun=Abun,
         nLevel=nLevel,
+        nBoundLevel=nBoundLevel,
         nLine=nLine,
         nCont=nCont,
         nTran=nTran,


### PR DESCRIPTION
## Summary

Resolves #28. `nLevel` counts both bound and continuum states. This adds a `nBoundLevel` field to the `Atom` struct that directly exposes the number of bound levels.

## Changes

- Added `nBoundLevel: T_INT` field to the `Atom` dataclass (after `nLevel`).
- Computed at both construction sites (`init_Atom_` and `init_theoretical_hydrogen_atom_`) as:
  ```python
  nBoundLevel = nLevel - 1 if _has_continuum else nLevel
  ```

## Design note

Implemented as a constructor-computed field rather than the issue's literal pseudo-code (`nBoundLevel: T_INT = nLevel - 1 if _has_continuum else nLevel`), because a dataclass default cannot reference sibling fields like `nLevel`/`_has_continuum`. This keeps it consistent with the existing `nLevel`/`nLine`/`nCont` pattern.

## Verification

- Theoretical H (`nLevel=8`, continuum present) → `nBoundLevel=7` ✓
- He from `He.conf` (`nLevel=27`) → `nBoundLevel=26` ✓
- Correctly handles `_has_continuum=False` (then `nBoundLevel == nLevel`).