### PR TITLE
feat(SEquil): export continuum wavelength mesh via SE_Container

### DIFF
--- a/src/spectra/Function/SEquil/SELib.py
+++ b/src/spectra/Function/SEquil/SELib.py
@@ -307,7 +307,7 @@ def cal_SE_(
 
     # Local placeholder: future continuum-shift work replaces this with a shifted
     # array. Today the continuum mesh is fixed (the flag above gates that path),
-    # so we use wMesh.Cont_mesh directly. Not exported via SE_Container.
+    # so we use wMesh.Cont_mesh directly. Exported via SE_Container.cont_wm_cm.
     cont_wave_mesh = Cont_mesh
 
     if PI_intensity is None:
@@ -400,6 +400,7 @@ def cal_SE_(
         Line_mesh_idxs=Line_mesh_idxs,
         Jbar=bj.Jbar_all,
         PI_intensity=PI_intensity,
+        cont_wm_cm=cont_wave_mesh,
         Ntotal=0.0,
         Nh=0.0,
         Ne=Ne,

--- a/src/spectra/Struct/Container/SEquil.py
+++ b/src/spectra/Struct/Container/SEquil.py
@@ -71,6 +71,11 @@ class SE_Container:
     ## interp(radiation.solar, wMesh.Cont_mesh). 2d (nCont, _N_CONT_MESH).
     PI_intensity: T_ARRAY  # 2d (nCont, _N_CONT_MESH), [erg/cm^2/Sr/cm/s]
 
+    ## Continuum wavelength mesh the bound-free quantities (PI_intensity, etc.)
+    ## are evaluated on. Currently fixed to wMesh.Cont_mesh (no doppler shift);
+    ## exported so callers can pair PI_intensity with its wavelength axis.
+    cont_wm_cm: T_ARRAY  # 2d (nCont, _N_CONT_MESH), [cm]
+
 
 @_dataclass(**STRUCT_KWGS_UNFROZEN)
 class SE_Params_Container:


### PR DESCRIPTION
## Goal

Export the continuum wavelength mesh (in cm) from `cal_SE_` so callers can pair `PI_intensity` with the wavelength axis it was evaluated on. Previously the mesh stayed internal to the SE call.

## Step 1 — Add the field to the result container

`SE_Container` already returns `PI_intensity` (2d `(nCont, _N_CONT_MESH)`) but not its wavelength axis, so callers had no way to know where those intensities sit in wavelength.

Add a sibling field:

```python
cont_wm_cm: T_ARRAY  # 2d (nCont, _N_CONT_MESH), [cm]
```

placed right after `PI_intensity` to keep the two bound-free quantities together, with a comment noting it is currently fixed to `wMesh.Cont_mesh` (no doppler shift).

## Step 2 — Populate it in `cal_SE_`

The local `cont_wave_mesh` already holds the continuum mesh used to drive bound-free rates. Wire it into the container:

```python
SE_Container(..., PI_intensity=PI_intensity, cont_wm_cm=cont_wave_mesh, ...)
```

The pre-existing inline note saying it was "Not exported via SE_Container" was updated to point at `SE_Container.cont_wm_cm`.

## Notes

- Unit is cm: `Cont_mesh` derives from `Cont["w0"]` (cm) via `init_Wave_Mesh_`.
- Only one `SE_Container` construction site, called with keyword args, so the new field is safe to append.
