### PR TITLE
feat(CloudModel): add optional background intensity to slab model

### DIFF
--- a/src/spectra/Experimental/ExLibTmp.py
+++ b/src/spectra/Experimental/ExLibTmp.py
@@ -1,6 +1,7 @@
 import numpy as _numpy
 
 from ..ImportAll import *
+from ..RadiativeTransfer import CloudModel as _RTCloud
 from ..Struct import Atom as _Atom
 
 # from ..Elements import ELEMENT_DICT as _ELEMENT_DICT
@@ -39,7 +40,7 @@ def extract_lprof(l: _CloudModel.CloudModel_Container, wmin: float, wmax: float,
         idx2 = l.Line_mesh_idxs[j, 1]
         tau1 = _numpy.interp(wl, l.wl_1D[idx1:idx2] * 1e8, l.tau_1D[idx1:idx2])
         # prof1 = np.interp(wl, l.wl_1D[idx1:idx2]*1e8, l.prof_1D[idx1:idx2])
-        prof1 = Ic * _numpy.exp(-tau1) + l.Src[j] * (1.0 - _numpy.exp(-tau1))
+        prof1 = _RTCloud.emergent_intensity_(l.Src[j], tau1, Ic)
         print(f"l.Src[{j}]={l.Src[j]:+.2E}")
         prof[:] += prof1
     return wl, prof

--- a/src/spectra/Function/SlabModel/CloudModel.py
+++ b/src/spectra/Function/SlabModel/CloudModel.py
@@ -6,6 +6,7 @@ import numpy as _numpy
 
 from ...ImportAll import *
 from ...Math import Integrate as _Integrate
+from ...RadiativeTransfer import CloudModel as _RTCloud
 from ...Struct import Atmosphere as _Atmosphere
 from ...Struct import Atom as _Atom
 from ...Struct import Container as _Container
@@ -16,6 +17,7 @@ def SE_to_slab_0D_(
     atmos: _Atmosphere.Atmosphere0D,
     SE_con: _Container.SE_Container,
     depth: T_FLOAT,
+    I0: T_ARRAY | None = None,
 ) -> _Container.CloudModel_Container:
     """calculate the optical depth and source function for a slab model.
 
@@ -25,6 +27,11 @@ def SE_to_slab_0D_(
     model reads only what it needs from `SE_con` (no `wMesh` dependency); SE
     already computed both `dopWidth_cm` (baked into `wm_cm_1d`) and the
     unshifted `absorb_prof_1d` (sampled at those same wavelengths).
+
+    `I0` is the optional background intensity entering the slab from behind,
+    given as a 2d table `(2, n_wavelength)` like `Radiation.solar` (row 0
+    wavelength [cm], row 1 intensity), or `None` for zero background. It is
+    interpolated once onto the observer-frame `wl_1D` so it aligns with `tau`.
     """
 
     nLine = atom.nLine
@@ -69,22 +76,37 @@ def SE_to_slab_0D_(
     arr_prof_1D = _numpy.empty_like(absorb_prof_1d)
     arr_tau_1D = _numpy.empty_like(absorb_prof_1d)
     arr_wl_1D = _numpy.empty_like(absorb_prof_1d)
+
+    # fill the full observer-frame wavelength mesh first, so the background
+    # intensity can be interpolated onto it in a single pass below.
+    for k in range(nLine):
+        i1 = Line_mesh_idxs[k, 0]
+        i2 = Line_mesh_idxs[k, 1]
+        # observer-frame wavelength mesh: sun-frame atom-rest-frame mesh
+        # shifted by +w0*Vd_obs/c. Astronomy radial-velocity convention:
+        # +Vd_obs = atom velocity AWAY from observer (source receding) →
+        # observer sees line center red-shifted to w0 + w0*Vd_obs/c.
+        arr_wl_1D[i1:i2] = wm_cm_1d[i1:i2] + (Line["w0"][k] * Vd_obs / CST.c_)
+
+    # one interpolation of the background onto the full observer-frame mesh;
+    # sliced per line below so it stays aligned with each line's tau.
+    if I0 is None:
+        bg_1D = _numpy.zeros_like(arr_wl_1D)
+    else:
+        if I0.shape[0] != 2:
+            raise ValueError(f"background intensity I0 must have shape (2, n_wavelength), but got {I0.shape}")
+        bg_1D = _numpy.interp(arr_wl_1D, I0[0, :], I0[1, :])
+
     for k in range(nLine):
         i1 = Line_mesh_idxs[k, 0]
         i2 = Line_mesh_idxs[k, 1]
 
         w0 = Line["w0"][k]
-        # observer-frame wavelength mesh: sun-frame atom-rest-frame mesh
-        # shifted by +w0*Vd_obs/c. Astronomy radial-velocity convention:
-        # +Vd_obs = atom velocity AWAY from observer (source receding) →
-        # observer sees line center red-shifted to w0 + w0*Vd_obs/c.
-        wl = wm_cm_1d[i1:i2] + (w0 * Vd_obs / CST.c_)
+        wl = arr_wl_1D[i1:i2]
 
         tau = depth * alp0[k] * absorb_prof_1d[i1:i2]
 
-        # TODO: this formula should be converted into an individual function,
-        # with background intensity as optional input argument.
-        prof = Src[k] * (1.0 - _numpy.exp(-tau[:]))
+        prof = _RTCloud.emergent_intensity_(Src[k], tau[:], bg_1D[i1:i2])
 
         # l.tau0[i] = np.max(tau)
         # l.prof[i][:] = S[i] * (1. - np.exp(-tau[:]))
@@ -99,7 +121,6 @@ def SE_to_slab_0D_(
         arr_Ibar[k] = Ibar
         arr_prof_1D[i1:i2] = prof[:]
         arr_tau_1D[i1:i2] = tau[:]
-        arr_wl_1D[i1:i2] = wl[:]
 
     cloud_con = _Container.CloudModel_Container(
         w0=arr_w0,

--- a/src/spectra/RadiativeTransfer/CloudModel.py
+++ b/src/spectra/RadiativeTransfer/CloudModel.py
@@ -1,0 +1,48 @@
+# -------------------------------------------------------------------------------
+# emergent intensity of a homogeneous slab / cloud
+# -------------------------------------------------------------------------------
+
+
+import numpy as _numpy
+
+from ..ImportAll import *
+
+
+# NOTE : replace with numba vectorize if necessary
+@_numpy.vectorize
+def emergent_intensity_(
+    Src: T_FLOAT,
+    tau: T_FLOAT,
+    I0: T_FLOAT = 0.0,
+) -> T_FLOAT:
+    r"""emergent intensity of a homogeneous slab illuminated from behind.
+
+    .. math:: I = S (1 - e^{-\tau}) + I_0 e^{-\tau}
+
+    Exact solution for a uniform source function `S` over a finite optical
+    depth `tau`; not restricted to the optically-thin regime.
+
+    `@_numpy.vectorize` makes this a ufunc: the body operates on scalars while
+    callers may pass arrays for `tau` / `I0` (broadcast elementwise).
+
+    Parameters
+    ----------
+    Src : T_FLOAT
+        source function of one line, constant along the slab (scalar per line).
+        [erg/cm^2/Sr/cm/s]
+    tau : T_FLOAT
+        optical depth across the slab at one wavelength. [-]
+    I0 : T_FLOAT
+        background intensity entering the slab from behind, aligned with `tau`.
+        0 ⇒ no background. [erg/cm^2/Sr/cm/s]
+
+    Returns
+    -------
+    T_FLOAT
+        emergent intensity. [erg/cm^2/Sr/cm/s]
+    """
+    # NOTE: for extreme population inversion (tau < ~-709) exp(-tau) overflows
+    # to +inf and the result is nan. Such tau is unphysical (maser runaway) and
+    # not a realistic slab input, so it is left unguarded.
+    transmission = _numpy.exp(-tau)
+    return Src * (1.0 - transmission) + I0 * transmission

--- a/src/spectra/Util/AtomUtils/AtomInfo.py
+++ b/src/spectra/Util/AtomUtils/AtomInfo.py
@@ -5,6 +5,7 @@
 import numpy as _numpy
 
 from ...ImportAll import *
+from ...RadiativeTransfer import CloudModel as _RTCloud
 from ...Struct import Atom as _Atom
 from ...Struct.Container import CloudModel as _CloudModel
 
@@ -59,7 +60,8 @@ def extract_lprof(l: _CloudModel.CloudModel_Container, wmin: T_FLOAT, wmax: T_FL
         idx2 = l.Line_mesh_idxs[j, 1]
         tau1 = _numpy.interp(wl, l.wl_1D[idx1:idx2] * 1e8, l.tau_1D[idx1:idx2])
         # prof1 = np.interp(wl, l.wl_1D[idx1:idx2]*1e8, l.prof_1D[idx1:idx2])
-        prof1 = l.Src[j] * (1.0 - _numpy.exp(-tau1))
+        # background applied once after the loop (see below), so pass I0=0 here.
+        prof1 = _RTCloud.emergent_intensity_(l.Src[j], tau1, 0.0)
         print("Ic, Src=", Ic, l.Src[j])
         tau += tau1
         profe += prof1


### PR DESCRIPTION
Closes #14.

Add an optional background intensity to the slab model so the emergent profile
becomes the exact finite-slab solution `I = S·(1−e^(−τ)) + I0·e^(−τ)`, and
factor the formula into one shared helper.

## Phase 1 — shared helper

Add `emergent_intensity_(Src, tau, I0=0.0)` in `RadiativeTransfer/CloudModel.py`.

- **Why here:** the formula is the exact uniform-slab solution (not thin-only),
  and `RadiativeTransfer` is the lowest layer, so `Function` / `Util` /
  `Experimental` can all import it without a cycle.
- **How:** `@_numpy.vectorize` scalar ufunc so callers broadcast arrays for
  `tau` / `I0`. Extreme negative `tau` (maser runaway) → `nan` is documented and
  left unguarded as unphysical.

## Phase 2 — wire into the slab model

Change `SE_to_slab_0D_(atom, atmos, SE_con, depth, I0=None)`.

- **Why `I0` is a 2D table / `None`, not a scalar:** a flat value can't align to
  each line's wavelength sub-mesh. `I0` is a `(2, n_wavelength)` table like
  `Radiation.solar`; `None` ⇒ zero background ⇒ output identical to before
  (trailing arg keeps existing positional callers working).
- **How:** fill the full observer-frame mesh first, interpolate `I0` onto it
  **once**, then slice per line so the background aligns element-wise with `tau`.

## Phase 3 — deduplicate the two copies

`extract_lprof(...)` in `Util/AtomUtils/AtomInfo.py` and
`Experimental/ExLibTmp.py` now call the helper.

- **Why two call patterns:** the copies apply the background differently —
  `ExLibTmp` per-line (`I0=Ic`), `AtomInfo` once over the summed `τ` (`I0=0.0`
  in-loop, background kept after the loop). Both reproduce prior output exactly.

## Verification

- `I0=None` reproduces previous numbers; full regression suite passes (262).
- Reviewed for bugs + over-engineering; no required changes.
