### PR TITLE
fix(Atomic): exact eps at bf continuum edge (Balmer-limit spike)

### DIFF
--- a/src/spectra/Atomic/emisivity.py
+++ b/src/spectra/Atomic/emisivity.py
@@ -47,6 +47,7 @@ def bf_emissivity_(
     gi: T_FLOAT,
     gk: T_FLOAT,
     chi: T_FLOAT,
+    w0: T_FLOAT,
 ) -> T_FLOAT:
     r"""bound-free (continuum) spectral emission coefficient :math:`j_\lambda`.
 
@@ -95,6 +96,10 @@ def bf_emissivity_(
     chi : T_FLOAT
         ionization energy from the lower (bound) level, :math:`\chi = h f_0`
         (continuum edge), [erg]
+    w0 : T_FLOAT
+        continuum edge wavelength :math:`\lambda_0 = c/f_0`, the same value used to
+        build the wavelength mesh ``wl``, [cm]. Used only to evaluate
+        :math:`\varepsilon` without catastrophic cancellation (see below).
 
     Returns
     -------
@@ -102,7 +107,19 @@ def bf_emissivity_(
         spectral b-f emissivity :math:`j_\lambda`, [erg/cm^3/s/Sr/cm]
     """
     nu = CST.c_ / wl
-    eps = CST.h_ * nu - chi
+    # eps = h*nu - chi, rearranged to avoid catastrophic cancellation at the edge.
+    # The idea: eps = h*nu - chi subtracts two nearly-equal large numbers, and nu
+    # is reconstructed from wl which itself came from f0 -- that round-trip
+    # (f0 -> w0=c/f0 -> nu=c/w0) is where the 1-ULP error crept in. Instead of
+    # round-tripping, rearrange the same formula so the edge term cancels exactly.
+    # With w0 = c/f0 and chi = h*f0 we have chi*w0 = h*c, so
+    #   h*nu - chi = h*c/wl - chi = chi*w0/wl - chi = chi*(w0 - wl)/wl,
+    # which is algebraically identical but, since the mesh edge column is wl == w0
+    # bitwise, evaluates to exactly 0 there. The direct form h*(c/wl) - h*f0
+    # round-trips f0 -> w0 -> f0 and can land 1 ULP negative at the edge, which
+    # the guard below would then wrongly zero out (the Balmer-limit spike).
+    eps = chi * (w0 - wl) / wl
+
     # below threshold (wl > edge, eps < 0) there is no recombination continuum;
     # return 0 rather than the analytically-continued exp(-eps/kTe) which would
     # blow up (and give 0*inf=nan when alpha==0). Production meshes are

--- a/src/spectra/Atomic/emisivity.py
+++ b/src/spectra/Atomic/emisivity.py
@@ -120,11 +120,15 @@ def bf_emissivity_(
     # the guard below would then wrongly zero out (the Balmer-limit spike).
     eps = chi * (w0 - wl) / wl
 
-    # below threshold (wl > edge, eps < 0) there is no recombination continuum;
-    # return 0 rather than the analytically-continued exp(-eps/kTe) which would
-    # blow up (and give 0*inf=nan when alpha==0). Production meshes are
-    # edge-first and stay at/below the edge, so this only guards misuse.
-    if eps < 0.0:
+    # below threshold (wl > edge) there is no recombination continuum; return 0
+    # rather than the analytically-continued exp(-eps/kTe) which would blow up
+    # (and give 0*inf=nan when alpha==0). The rearrangement above makes eps
+    # exactly 0 at the edge for meshes built from w0. The small tolerance (~1e-9
+    # of chi: far above 1 ULP, far below kTe) is a belt-and-suspenders guard for
+    # a caller whose wl was NOT built from this exact w0 and rounds a hair past
+    # the edge -- such a point stays on the emitting side, where eps is a tiny
+    # negative and exp(-eps/kTe) ~ 1 is finite.
+    if eps < -1.0e-9 * chi:
         return 0.0
     # sigma_fb * f(eps)v with the divergent factors cancelled analytically:
     #   - eps: 1/eps (sigma_fb) * eps (Maxwell flux) -> 1  (this is what removes

--- a/src/spectra/Function/SlabModel/CloudModel.py
+++ b/src/spectra/Function/SlabModel/CloudModel.py
@@ -271,7 +271,7 @@ def _SE_to_slab_0D_bf_(
         # population of the next-higher-ion ground level (proton for hydrogen).
         Ni1: T_ARRAY = n_SE[Cont["idxJ"][k]] * N_ele
 
-        emi = _emisivity.bf_emissivity_(wl, alpha, Te, Ne, Ni1, gi, gk, chi)
+        emi = _emisivity.bf_emissivity_(wl, alpha, Te, Ne, Ni1, gi, gk, chi, Cont["w0"][k])
         ext = _extinction.bf_extinction_(wl, alpha, Te, Ni)
 
         tau = depth * ext


### PR DESCRIPTION
Closes #42, closes #45.

The bf (recombination) continuum showed a spurious vertical spike to the log
floor **only at the Balmer limit** (~3646 Å): the emissivity of that edge column
came out exactly `0`. Root cause is a 1-ULP floating-point round-trip in the edge
energy `eps = h*nu - chi`. Two phases below.

## Phase 1 — exact `eps` at the edge (root cause)

**Why.** `bf_emissivity_(...)` computed `nu = c/wl` then `eps = h*nu - chi`, with
`chi = h*f0` and the mesh edge column `wl == w0 == c/f0`. So `nu = c/(c/f0)` is a
round-trip through two separately-rounded divisions and lands at `f0 +/- 1 ULP`.
Whichever way it rounds is luck of the bits; for n=2 it landed `eps = -8e-28`,
tripping the `if eps < 0.0: return 0.0` guard and zeroing the Balmer edge. All
other levels rounded to exactly `0`.

**How.** Rearrange the *same* formula to avoid the cancellation. With `w0 = c/f0`
and `chi = h*f0`, `chi*w0 = h*c`, so:

```
eps = h*nu - chi = chi*w0/wl - chi = chi*(w0 - wl)/wl
```

The mesh edge column is `wl == w0` bitwise (mesh is `w0 * 1.0`), so `(w0 - wl)`
is exactly `0` there → `eps == 0` exactly, for every series, independent of the
level energies. `bf_emissivity_(...)` gains a `w0` parameter and the single caller
`_SE_to_slab_0D_bf_(...)` passes `Cont["w0"][k]`.

## Phase 2 — tolerant edge guard (safety net)

**Why.** Phase 1 is exact only for meshes built from `w0`. A future caller with a
`wl` not built from this exact `w0` (e.g. an interpolated grid) could still round
a hair past the edge.

**How.** Relax the hard cut to a small tolerance, far above 1 ULP and far below
`kTe`:

```
if eps < -1.0e-9 * chi:
    return 0.0
```

A point that rounds a hair past the edge stays on the emitting side (`eps` a tiny
negative, `exp(-eps/kTe) ~ 1`, finite); only genuine sub-threshold points return 0.

## Result

n=2 edge emissivity goes from `0.0` → `3.06e+01` (between n=1 and n=3). All other
levels are bitwise unchanged; full suite `262 passed`.
