### PR TITLE
refactor(Atom): init_Atom_ returns Atom only (#41)

### DIFF
--- a/notebooks/demo/hydrogen_doppler/build_notebook.py
+++ b/notebooks/demo/hydrogen_doppler/build_notebook.py
@@ -167,7 +167,7 @@ CONF_PATH = str(CFG._ROOT_DIR / "data/conf/H.conf")
 DEPTH = 1.0e3 * 1.0e5  # 1000 km slab in cm
 COLORS = ["C0", "k", "C3"]  # blue / black / red, used as -, 0, + velocity throughout
 
-atom, _ = Atom.init_Atom_(CONF_PATH, is_hydrogen=True)
+atom = Atom.init_Atom_(CONF_PATH, is_hydrogen=True)
 radiation = Radiation.init_Radiation_()
 
 

--- a/notebooks/demo/hydrogen_doppler/hydrogen_doppler.ipynb
+++ b/notebooks/demo/hydrogen_doppler/hydrogen_doppler.ipynb
@@ -179,7 +179,7 @@
     "DEPTH = 1.0e3 * 1.0e5  # 1000 km slab in cm\n",
     "COLORS = [\"C0\", \"k\", \"C3\"]  # blue / black / red, used as -, 0, + velocity throughout\n",
     "\n",
-    "atom, _ = Atom.init_Atom_(CONF_PATH, is_hydrogen=True)\n",
+    "atom = Atom.init_Atom_(CONF_PATH, is_hydrogen=True)\n",
     "radiation = Radiation.init_Radiation_()\n",
     "\n",
     "\n",

--- a/scripts/gen_atom_reference.py
+++ b/scripts/gen_atom_reference.py
@@ -24,6 +24,7 @@ from _atom_serde import dump_atom  # noqa: E402  # pyright: ignore[reportMissing
 
 from spectra import Configurations as CFG  # noqa: E402
 from spectra.Struct import Atom  # noqa: E402
+from spectra.Util.AtomUtils import AtomIO as _AtomIO  # noqa: E402
 
 # (relative conf path from repo root, readable name, is_hydrogen)
 CONFIGS: tuple[tuple[str, str, bool], ...] = (
@@ -47,7 +48,8 @@ def main() -> None:
     for rel, name, is_H in CONFIGS:
         conf_path = str(CFG._ROOT_DIR / rel)
         print(f"loading {name}  <- {rel}", flush=True)
-        atom, path_dict = Atom.init_Atom_(conf_path, is_hydrogen=is_H)
+        atom = Atom.init_Atom_(conf_path, is_hydrogen=is_H)
+        path_dict = _AtomIO.read_conf_(conf_path)
         merged.update(dump_atom(atom, path_dict, name))
 
     out.parent.mkdir(parents=True, exist_ok=True)

--- a/src/spectra/Struct/Atom.py
+++ b/src/spectra/Struct/Atom.py
@@ -106,7 +106,7 @@ class Atom:
 # -------------------------------------------------------------------------------
 
 
-def init_Atom_(conf_path: T_STR, is_hydrogen: T_BOOL = False) -> T_TUPLE[Atom, T_DICT[T_STR, None | T_STR]]:
+def init_Atom_(conf_path: T_STR, is_hydrogen: T_BOOL = False) -> Atom:
     """given the *.conf file, create the Atom struct
 
     Parameters
@@ -118,12 +118,13 @@ def init_Atom_(conf_path: T_STR, is_hydrogen: T_BOOL = False) -> T_TUPLE[Atom, T
 
     Returns
     -------
-    T_TUPLE[Atom, T_DICT[T_STR, None | T_STR]]
-
     atom : Atom
         the Atom struct (the wavelength mesh is stored on ``atom._wave_mesh``)
-    path_dict : T_DICT[T_STR, None | T_STR]
-        a dictionary of the path of data files
+
+    Notes
+    -----
+    If the data-file paths are needed, obtain them separately via
+    ``_AtomIO.read_conf_(conf_path)``.
     """
 
     # path dict
@@ -256,7 +257,7 @@ def init_Atom_(conf_path: T_STR, is_hydrogen: T_BOOL = False) -> T_TUPLE[Atom, T
         RL=RL,
         _wave_mesh=waveMesh,
     )
-    return atom, path_dict
+    return atom
 
 
 def init_theoretical_hydrogen_atom_(

--- a/tests/examples/example.CM.py
+++ b/tests/examples/example.CM.py
@@ -4,7 +4,7 @@ from spectra.ImportAll import *
 from spectra.Struct import Atmosphere, Atom, Radiation
 
 conf_path = CFG._ROOT_DIR / "data/conf/H.conf"
-atom, path_dict = Atom.init_Atom_(str(conf_path), is_hydrogen=True)
+atom = Atom.init_Atom_(str(conf_path), is_hydrogen=True)
 
 atmos = Atmosphere.Atmosphere0D(Nh=1.0e12, Ne=1.0e11, Te=7.0e3, Vt=5.0e5)
 radiation = Radiation.init_Radiation_()

--- a/tests/examples/example.H_Grotrian.py
+++ b/tests/examples/example.H_Grotrian.py
@@ -23,6 +23,7 @@ import matplotlib.pyplot as plt
 
 from spectra.ImportAll import *
 from spectra.Struct import Atom
+from spectra.Util.AtomUtils import AtomIO as _AtomIO
 from spectra.Visual.Grotrian import Grotrian
 
 
@@ -36,7 +37,8 @@ def scaleFunc_inv(x):
 
 def main():
     conf_path = CFG._ROOT_DIR / "data" / "conf" / "H.conf"
-    atom, path_dict = Atom.init_Atom_(str(conf_path), is_hydrogen=True)
+    atom = Atom.init_Atom_(str(conf_path), is_hydrogen=True)
+    path_dict = _AtomIO.read_conf_(str(conf_path))
 
     print(f"[before construct] fignums = {plt.get_fignums()}")
     gro = Grotrian(

--- a/tests/examples/example.He.py
+++ b/tests/examples/example.He.py
@@ -3,7 +3,7 @@ from spectra.ImportAll import *
 from spectra.Struct import Atmosphere, Atom, Radiation
 
 conf_path = CFG._ROOT_DIR / "data" / "conf" / "He.conf"
-atom, path_dict = Atom.init_Atom_(str(conf_path), is_hydrogen=False)
+atom = Atom.init_Atom_(str(conf_path), is_hydrogen=False)
 
 atmos = Atmosphere.Atmosphere0D(Nh=1.0e11, Ne=5.0e10, Te=7.0e3, Vt=5.0e5)
 radiation = Radiation.init_Radiation_()

--- a/tests/examples/example.SE.py
+++ b/tests/examples/example.SE.py
@@ -3,7 +3,7 @@ from spectra.ImportAll import *
 from spectra.Struct import Atmosphere, Atom, Radiation
 
 conf_path = CFG._ROOT_DIR / "data/conf/H.conf"
-atom, path_dict = Atom.init_Atom_(str(conf_path), is_hydrogen=True)
+atom = Atom.init_Atom_(str(conf_path), is_hydrogen=True)
 
 atmos = Atmosphere.Atmosphere0D(Nh=1.0e12, Ne=1.0e11, Te=7.0e3, Vt=5.0e5)
 radiation = Radiation.init_Radiation_()

--- a/tests/examples/example.help.py
+++ b/tests/examples/example.help.py
@@ -3,6 +3,6 @@ from spectra.Struct import Atom
 from spectra.Util import HelpUtil
 
 conf_path = CFG._ROOT_DIR / "data/conf/H.conf"
-atom, path_dict = Atom.init_Atom_(str(conf_path), is_hydrogen=True)
+atom = Atom.init_Atom_(str(conf_path), is_hydrogen=True)
 
 HelpUtil.help_(atom)

--- a/tests/regression/_atom_serde.py
+++ b/tests/regression/_atom_serde.py
@@ -1,9 +1,10 @@
 """Serialization and assertion helpers for Atom regression tests.
 
-Flattens the `(atom, path_dict)` tuple returned by `Atom.init_Atom_()`
-(the wavelength mesh is read from ``atom._wave_mesh``) into a flat
-``{key: json_value}`` dict suitable for JSON storage, and provides the
-reverse comparison used by ``test_reg_e2e_AtomLoad.py``.
+Flattens the ``Atom`` produced by `Atom.init_Atom_()` together with its
+``path_dict`` (read separately via ``AtomIO.read_conf_()``; the wavelength
+mesh is read from ``atom._wave_mesh``) into a flat ``{key: json_value}``
+dict suitable for JSON storage, and provides the reverse comparison used
+by ``test_reg_e2e_AtomLoad.py``.
 
 Design notes
 ------------

--- a/tests/regression/test_reg_e2e_AtomLoad.py
+++ b/tests/regression/test_reg_e2e_AtomLoad.py
@@ -1,10 +1,10 @@
 """Regression tests for the AtomIO load pipeline.
 
 For each of 8 canonical configurations, loads the atom via
-``Atom.init_Atom_()`` and asserts that every field of the returned
-``(atom, path_dict)`` tuple (the wavelength mesh is read from
-``atom._wave_mesh``) matches the reference snapshot in
-``atom_reference_values.json``.
+``Atom.init_Atom_()`` (with the data-file paths read separately via
+``AtomIO.read_conf_()``) and asserts that every field of the atom (the
+wavelength mesh is read from ``atom._wave_mesh``) and every path matches
+the reference snapshot in ``atom_reference_values.json``.
 
 The snapshot was generated at commit ``a84128b`` (pre-refactoring) and
 bit-exact equal to a snapshot generated on current ``main``, confirming
@@ -17,6 +17,7 @@ import pytest
 
 from spectra.ImportAll import CFG
 from spectra.Struct import Atom
+from spectra.Util.AtomUtils import AtomIO as _AtomIO
 
 from ._atom_serde import assert_atom_matches
 
@@ -40,5 +41,6 @@ _CONFIGS: list[tuple[str, str, bool]] = [
 )
 def test_load_atom_matches_reference(conf_rel: str, name: str, is_hydrogen: bool, ref_atom):
     conf_path = str(CFG._ROOT_DIR / conf_rel)
-    atom, path_dict = Atom.init_Atom_(conf_path, is_hydrogen=is_hydrogen)
+    atom = Atom.init_Atom_(conf_path, is_hydrogen=is_hydrogen)
+    path_dict = _AtomIO.read_conf_(conf_path)
     assert_atom_matches(atom, path_dict, name, ref_atom)

--- a/tests/regression/test_reg_e2e_CloudModel.py
+++ b/tests/regression/test_reg_e2e_CloudModel.py
@@ -13,7 +13,7 @@ from .conftest import assert_close
 class TestHydrogenCloudModel:
     def test_slab_0D(self, ref):
         conf_path = str(CFG._ROOT_DIR / "data/conf/H.conf")
-        atom, _ = Atom.init_Atom_(conf_path, is_hydrogen=True)
+        atom = Atom.init_Atom_(conf_path, is_hydrogen=True)
 
         atmos = Atmosphere.Atmosphere0D(Nh=1.0e12, Ne=1.0e11, Te=7.0e3, Vt=5.0e5)
         radiation = Radiation.init_Radiation_()
@@ -37,7 +37,7 @@ class TestHydrogenCloudModel:
         valid because they don't depend on populations).
         """
         conf_path = str(CFG._ROOT_DIR / "data/conf/H.conf")
-        atom, _ = Atom.init_Atom_(conf_path, is_hydrogen=True)
+        atom = Atom.init_Atom_(conf_path, is_hydrogen=True)
 
         atmos = Atmosphere.Atmosphere0D(Nh=1.0e12, Ne=1.0e11, Te=7.0e3, Vt=5.0e5)
         radiation = Radiation.init_Radiation_()

--- a/tests/regression/test_reg_e2e_SE.py
+++ b/tests/regression/test_reg_e2e_SE.py
@@ -13,7 +13,7 @@ class TestHydrogenSE:
         return Atom.init_Atom_(conf_path, is_hydrogen=True)
 
     def test_SE_with_Nh_Te(self, ref):
-        atom, _ = self._load_H()
+        atom = self._load_H()
         atmos = Atmosphere.Atmosphere0D(Nh=1.0e12, Ne=1.0e11, Te=7.0e3, Vt=5.0e5)
         radiation = Radiation.init_Radiation_()
         SE_con, _ = SELib.cal_SE_with_Nh_Te_(atom, atmos, radiation, None)
@@ -23,7 +23,7 @@ class TestHydrogenSE:
         assert_close(atmos.Ne, ref["E2E.H_SE_Nh_Te.Ne"], rtol=1e-8)
 
     def test_SE_with_Ne_Te(self, ref):
-        atom, _ = self._load_H()
+        atom = self._load_H()
         atmos = Atmosphere.Atmosphere0D(Nh=1.0e11, Ne=5.0e10, Te=7.0e3, Vt=5.0e5)
         radiation = Radiation.init_Radiation_()
         SE_con, _ = SELib.cal_SE_with_Ne_Te_(atom, atmos, radiation, None)
@@ -32,7 +32,7 @@ class TestHydrogenSE:
         assert_close(SE_con.n_LTE, ref["E2E.H_SE_Ne_Te.n_LTE"], rtol=1e-8)
 
     def test_SE_with_Pg_Te(self, ref):
-        atom, _ = self._load_H()
+        atom = self._load_H()
         # Nh/Ne are overwritten by cal_SE_with_Pg_Te_ for H (is_hydrogen=True
         # branch sets both from Pg); values here are placeholder only.
         atmos = Atmosphere.Atmosphere0D(Pg=1.8, Nh=1.0e12, Ne=1.0e11, Te=7.0e3, Vt=5.0e5)
@@ -51,7 +51,7 @@ class TestHeliumSE:
         return Atom.init_Atom_(conf_path, is_hydrogen=False)
 
     def test_SE_with_Ne_Te(self, ref):
-        atom, _ = self._load_He()
+        atom = self._load_He()
 
         atmos = Atmosphere.Atmosphere0D(Nh=1.0e11, Ne=5.0e10, Te=7.0e3, Vt=5.0e5)
         radiation = Radiation.init_Radiation_()
@@ -61,7 +61,7 @@ class TestHeliumSE:
         assert_close(SE_con.n_LTE, ref["E2E.He_SE_Ne_Te.n_LTE"], rtol=1e-8)
 
     def test_SE_with_Nh_Te(self, ref):
-        atom, _ = self._load_He()
+        atom = self._load_He()
         atmos = Atmosphere.Atmosphere0D(Nh=1.0e12, Ne=1.0e11, Te=7.0e3, Vt=5.0e5)
         radiation = Radiation.init_Radiation_()
         SE_con, _ = SELib.cal_SE_with_Nh_Te_(atom, atmos, radiation, None)
@@ -73,7 +73,7 @@ class TestHeliumSE:
         assert_close(SE_con.Ntotal, ref["E2E.He_SE_Nh_Te.Ntotal"], rtol=1e-8)
 
     def test_SE_with_Pg_Te(self, ref):
-        atom, _ = self._load_He()
+        atom = self._load_He()
         # Pg is unused by cal_SE_with_Pg_Te_ for non-H atoms; Nh/Ne drive the result.
         atmos = Atmosphere.Atmosphere0D(Pg=1.8, Nh=1.0e12, Ne=1.0e11, Te=7.0e3, Vt=5.0e5)
         radiation = Radiation.init_Radiation_()
@@ -90,7 +90,7 @@ class TestCaIISE:
         return Atom.init_Atom_(conf_path, is_hydrogen=False)
 
     def test_SE_with_Nh_Te(self, ref):
-        atom, _ = self._load_Ca_II()
+        atom = self._load_Ca_II()
         atmos = Atmosphere.Atmosphere0D(Nh=1.0e12, Ne=1.0e11, Te=7.0e3, Vt=5.0e5)
         radiation = Radiation.init_Radiation_()
         SE_con, _ = SELib.cal_SE_with_Nh_Te_(atom, atmos, radiation, None)
@@ -101,7 +101,7 @@ class TestCaIISE:
         assert_close(SE_con.Ntotal, ref["E2E.Ca_II_SE_Nh_Te.Ntotal"], rtol=1e-8)
 
     def test_SE_with_Ne_Te(self, ref):
-        atom, _ = self._load_Ca_II()
+        atom = self._load_Ca_II()
         atmos = Atmosphere.Atmosphere0D(Nh=1.0e11, Ne=5.0e10, Te=7.0e3, Vt=5.0e5)
         radiation = Radiation.init_Radiation_()
         SE_con, _ = SELib.cal_SE_with_Ne_Te_(atom, atmos, radiation, None)
@@ -114,7 +114,7 @@ class TestCaIISE:
         assert_close(SE_con.n_LTE, ref["E2E.Ca_II_SE_Ne_Te.n_LTE"], rtol=1e-8)
 
     def test_SE_with_Pg_Te(self, ref):
-        atom, _ = self._load_Ca_II()
+        atom = self._load_Ca_II()
         atmos = Atmosphere.Atmosphere0D(Pg=1.8, Nh=1.0e12, Ne=1.0e11, Te=7.0e3, Vt=5.0e5)
         radiation = Radiation.init_Radiation_()
         SE_con, _ = SELib.cal_SE_with_Pg_Te_(atom, atmos, radiation, None)

--- a/tests/unittest/test.SE.H_I.py
+++ b/tests/unittest/test.SE.H_I.py
@@ -16,7 +16,7 @@ class Test_SE_With_H_I(unittest.TestCase):
         super().__init__(*args, **kwargs)
 
         conf_path = CFG._ROOT_DIR / "data/conf/H.conf"
-        atom, _path_dict = Atom.init_Atom_(str(conf_path), is_hydrogen=True)
+        atom = Atom.init_Atom_(str(conf_path), is_hydrogen=True)
 
         atmos = Atmosphere.Atmosphere0D(Nh=1.0e12, Ne=1.0e11, Te=7.0e3, Vt=5.0e5)
         radiation = Radiation.init_Radiation_()

--- a/tests/unittest/test.doppler_split.py
+++ b/tests/unittest/test.doppler_split.py
@@ -20,7 +20,7 @@ _FAL_PATH = CFG._ROOT_DIR / "data/atmos/FAL/FALC_82.atmos"
 
 
 def _hydrogen_setup(Vd_obs: float = 0.0, Vd_sun: float = 0.0):
-    atom, _ = Atom.init_Atom_(_CONF_PATH, is_hydrogen=True)
+    atom = Atom.init_Atom_(_CONF_PATH, is_hydrogen=True)
     wMesh = atom._wave_mesh
     atmos = Atmosphere.Atmosphere0D(
         Nh=1.0e12,


### PR DESCRIPTION
Closes #41.

`init_Atom_` returned a `(Atom, path_dict)` tuple, forcing every caller to
unpack and carry a `path_dict` most of them never used. This makes the
function return `Atom` only; callers that still need the data-file paths read
them independently via `read_conf_`.

The two functions already share the same source: `init_Atom_` builds its
`path_dict` by calling `read_conf_` internally, and never mutates it
afterward. So a caller calling `read_conf_` separately gets a byte-identical
dict — the change is behaviour-preserving.

### Phase 1 — change the return contract

In `src/spectra/Struct/Atom.py`, narrow the signature and return value:

- `def init_Atom_(conf_path, is_hydrogen=False) -> Atom` (was `-> T_TUPLE[Atom, T_DICT[...]]`)
- `return atom` (was `return atom, path_dict`)
- Docstring `Returns` trimmed to the atom; added a `Notes` line pointing
  callers to `read_conf_(conf_path)` when paths are needed.

### Phase 2 — adapt callers that discard `path_dict`

Most callers only wanted the atom. Drop the unpacking:

- `tests/regression/test_reg_e2e_SE.py`: `_load_H()` / `_load_He()` /
  `_load_Ca_II()` already returned the tuple through; call sites change from
  `atom, _ = self._load_X()` to `atom = self._load_X()`.
- `tests/regression/test_reg_e2e_CloudModel.py`, `tests/unittest/test.SE.H_I.py`,
  `tests/unittest/test.doppler_split.py`, and `tests/examples/example.{help,He,SE,CM}.py`:
  `atom, _ = init_Atom_(...)` → `atom = init_Atom_(...)`.

### Phase 3 — adapt callers that use `path_dict`

These genuinely need the paths, so they call `read_conf_` with the same
`conf_path`:

- `tests/examples/example.H_Grotrian.py` (uses `path_dict["Grotrian"]`)
- `scripts/gen_atom_reference.py` and `tests/regression/test_reg_e2e_AtomLoad.py`
  (feed `path_dict` into `dump_atom` / `assert_atom_matches`)

Each adds `from spectra.Util.AtomUtils import AtomIO` and inserts:

- `path_dict = read_conf_(conf_path)`

### Phase 4 — sync stale docstrings

`tests/regression/_atom_serde.py` and `test_reg_e2e_AtomLoad.py` module
docstrings described the old `(atom, path_dict)` tuple; reworded to the
"atom + separately-read path_dict" flow. No behavioural change.

### Verification

- Regenerated `atom_reference_values.json` — byte-identical to the committed
  reference, confirming `read_conf_` yields the same `path_dict`.
- `test_reg_e2e_AtomLoad`, `test_reg_e2e_SE`, `test_reg_e2e_CloudModel`,
  `test.doppler_split`, and the five example scripts pass.
- Notebooks intentionally untouched.

Pre-existing, unrelated: `tests/unittest/test.SE.H_I.py` fails on stale
hardcoded SE values (fails identically on `main`); the atom load itself is
identical.
