### PR TITLE
fix(Radiation): bridge NaN samples in the solar atlas on load

### DIFF
--- a/src/spectra/Struct/Radiation.py
+++ b/src/spectra/Struct/Radiation.py
@@ -22,7 +22,22 @@ def init_Radiation_(path: _Path | None = None) -> Radiation:
     Continuum PI intensity is built on demand by `cal_SE_` from `radiation.solar`
     and `wMesh.Cont_mesh` (or from `planck(Tr)` when `se_params.Tr is not None`);
     it is not cached here.
+
+    NaN intensity samples in the atlas are bridged linearly on load. The atlas
+    is consumed exclusively through `numpy.interp`, which does not treat NaN as
+    a gap: a query landing in an interval that merely *touches* a NaN sample
+    returns NaN. That NaN then travels Jbar -> the SE rate matrix -> a linear
+    solve, so a single bad sample turns *every* level population of the atom
+    into NaN. Which lines reach a bad sample depends on the Doppler width, so
+    left unfilled the defect surfaces as a silent blow-up above some threshold
+    in Te/Vt rather than as a localized wavelength artifact.
     """
     if path is None:
         path = CFG._ROOT_DIR / "data" / "intensity" / "atlas" / "QS" / "atlas_QS.20221118.npy"
-    return Radiation(solar=_numpy.load(path))
+    solar: T_ARRAY = _numpy.load(path)
+
+    bad = _numpy.isnan(solar[1, :])
+    if bad.any():
+        solar[1, bad] = _numpy.interp(solar[0, bad], solar[0, ~bad], solar[1, ~bad])
+
+    return Radiation(solar=solar)

--- a/tests/regression/test_reg_Radiation.py
+++ b/tests/regression/test_reg_Radiation.py
@@ -1,0 +1,60 @@
+"""Regression tests for the shipped solar atlas and its load-time NaN fill.
+
+The atlas is read only through ``numpy.interp``, which does not skip NaN: a
+query in an interval *adjacent* to a NaN sample returns NaN, and that NaN
+propagates through Jbar into the SE rate matrix, making every level population
+of the atom NaN. ``init_Radiation_`` therefore bridges the bad samples on load.
+
+These tests pin the defect itself, not just the fix. If a re-issued atlas grows
+a new NaN sample, ``test_atlas_nan_samples_are_the_known_four`` fails loudly
+instead of the fill silently absorbing it -- a wider gap may need real data
+rather than linear interpolation.
+"""
+
+import numpy as np
+import pytest
+
+from spectra.ImportAll import CFG
+from spectra.Struct import Radiation
+
+_ATLAS_PATH = CFG._ROOT_DIR / "data" / "intensity" / "atlas" / "QS" / "atlas_QS.20221118.npy"
+
+# Air wavelengths [AA] of every NaN intensity sample in the shipped atlas.
+_KNOWN_NAN_AA = np.array([1799.875, 2201.125, 2245.375, 2707.625])
+
+# The atlas grid step is 0.25 AA; 1e-3 pins the sample without pinning float noise.
+_WAVELENGTH_ATOL_AA = 1.0e-3
+
+
+@pytest.fixture(scope="module")
+def raw_atlas() -> np.ndarray:
+    """The atlas exactly as stored on disk, before ``init_Radiation_`` fills it."""
+    return np.load(_ATLAS_PATH)
+
+
+def test_atlas_nan_samples_are_the_known_four(raw_atlas: np.ndarray) -> None:
+    bad_AA = raw_atlas[0, np.isnan(raw_atlas[1, :])] * 1.0e8
+
+    assert bad_AA.size == _KNOWN_NAN_AA.size, (
+        f"expected {_KNOWN_NAN_AA.size} NaN samples in the atlas, found {bad_AA.size} at {bad_AA} AA"
+    )
+    assert np.allclose(np.sort(bad_AA), _KNOWN_NAN_AA, atol=_WAVELENGTH_ATOL_AA, rtol=0.0)
+
+
+def test_atlas_wavelength_axis_has_no_nan(raw_atlas: np.ndarray) -> None:
+    # The fill interpolates *against* row 0, so a NaN there would poison every
+    # filled value rather than a single sample.
+    assert not np.isnan(raw_atlas[0, :]).any()
+
+
+def test_init_Radiation_fills_every_nan() -> None:
+    assert not np.isnan(Radiation.init_Radiation_().solar).any()
+
+
+def test_fill_stays_between_its_neighbours(raw_atlas: np.ndarray) -> None:
+    # Linear interpolation is only defensible while the gaps stay one sample
+    # wide; a bracketing check catches a widened gap that a NaN count would not.
+    solar = Radiation.init_Radiation_().solar
+    for i in np.flatnonzero(np.isnan(raw_atlas[1, :])):
+        lo, hi = sorted((raw_atlas[1, i - 1], raw_atlas[1, i + 1]))
+        assert lo <= solar[1, i] <= hi


### PR DESCRIPTION
Closes #61.

Statistical equilibrium returned `NaN` for **all 45** levels of the
`Ca_I-II-III` model once `Vt` crossed ~20 km/s, and was clean below it. The
cause is four `NaN` intensity samples in the shipped solar atlas. This bridges
them at load time and pins the defect with a regression test.

---

## Phase 1 — locate where the `NaN` enters

**Why.** The symptom pointed at the solver (a whole population vector going
`NaN` looks like a singular matrix), and at `Vt` (the only parameter that moved).
Neither is the cause, so the first job was to find the earliest `NaN` rather
than to start hardening the solve.

**How.** Instrumented the pipeline at each stage boundary and swept
`Vt = 5 … 25 km/s`, counting `NaN`s in the output of every stage. The counts
placed the origin upstream of the solve and upstream of the profile: `n_SE` was
already `NaN` before any cloud-model quantity was formed, while the absorption
profile — the one thing that obviously depends on `Vt` — was clean throughout.

That narrowed it to the mean intensity. At `Vt = 20` exactly one entry of
`Jbar` was `NaN`, for the Ca line at 1807.337 Å, and the corresponding
interpolated background intensity slice held exactly one `NaN` while its
wavelength mesh and profile held none.

**Result.** The `NaN` is not computed. It is *read*.

## Phase 2 — confirm the source data is defective

**Why.** An interpolated intensity can only be `NaN` if the source is `NaN`,
the query is `NaN`, or the axis is unsorted. Phase 1 ruled out a `NaN` query.

**How.** Inspected `data/intensity/atlas/QS/atlas_QS.20221118.npy` directly:
the wavelength axis is strictly increasing and `NaN`-free, and the intensity
row carries exactly four `NaN` samples, at

```
1799.875 Å    2201.125 Å    2245.375 Å    2707.625 Å
```

**Result.** A data defect, not a physics or numerics one.

## Phase 3 — explain the `Vt` threshold

**Why.** A static data defect has to explain a *dynamic* threshold, otherwise
the diagnosis is incomplete and the fix might be aimed at the wrong layer.

**How.** The atlas is read only through `numpy.interp`, which does **not** treat
`NaN` as a gap to skip — a query inside an interval that merely *touches* a bad
sample interpolates between `NaN` and a finite neighbour and returns `NaN`. So
the question is when a line's wavelength mesh first reaches such an interval.

`_B_Jbar_()` builds each line's mesh as `w0 ± qwing * dopWidth`, with
`dopWidth = doppler_width_(w0, Te, Vt, Mass)` — and `dopWidth ∝ sqrt(2kT/m + Vt²)`,
so the mesh widens with `Vt`. Tabulating the blue edge of the 1807.337 Å line
(`qwing = 60`, `Te = 9000 K`, Ca mass):

| `Vt` [km/s] | `dopWidth` [Å] | mesh blue edge [Å] |
|---|---|---|
| 15 | 0.0912 | 1801.87 |
| 18 | 0.1091 | 1800.79 |
| 19 | 0.1151 | 1800.43 |
| **20** | 0.1211 | **1800.07** |

The poisoned interval is `[1799.875, 1800.125]`. The mesh edge enters it between
19 and 20 km/s — exactly the reported flip.

**Result.** The threshold is fully explained, and the propagation is understood
end to end: one bad sample → `Jbar` for one line → the `Bij_Jbar` / `Bji_Jbar`
radiative rates → one `NaN` row in the rate matrix → a linear solve whose result
is `NaN` in **every** level, not just the offending transition.

## Phase 4 — fix at load time

**Why this layer.** Three options were on the table: patch the notebook, patch
`init_Radiation_()`, or rewrite the `.npy`. Load time won on two grounds.

Every consumer reaches the atlas through this one struct, so fixing here fixes
all of them at once and leaves the shipped data file untouched and auditable.
More importantly, the damage is **non-local**: by the time a `NaN` is
observable it has already spread across an entire population vector, with no
trace of which wavelength caused it. A defect whose blast radius is that much
larger than its footprint should be neutralized at the boundary where the data
enters, not wherever it happens to detonate.

**How.** In `init_Radiation_()`, after the load, the bad samples are bridged by
linear interpolation against the (clean) wavelength axis. The guard is
unconditional and cheap — it costs one `isnan` scan per load and does nothing
when the array is clean, so a future corrected atlas needs no code change.

Note this is deliberately *not* a general "clean the data" helper: it handles
the one failure mode that is proven to exist. See
`Struct.Radiation.init_Radiation_(path)`.

The docstring records the reasoning, not the mechanics — specifically that
`numpy.interp` does not skip `NaN`, and that the resulting failure is a silent
threshold in `Te`/`Vt` rather than a localized wavelength artifact. That is the
part a future reader cannot recover from the three lines of code.

## Phase 5 — pin the defect, not just the fix

**Why.** A test that only asserts "the loaded struct has no `NaN`" would pass
forever, including on a re-issued atlas whose gaps are three samples wide —
where linear interpolation is no longer defensible and real data is needed.
The valuable assertion is about the *input*.

**How.** `tests/regression/test_reg_Radiation.py` reads the `.npy` directly,
before any filling, and asserts there are exactly four `NaN` samples at the four
known wavelengths (0.001 Å tolerance against a 0.25 Å grid). Count and values
are asserted separately so a fifth bad sample reports its wavelength in the
failure message rather than just a count mismatch.

Three companion checks close the remaining gaps:

- the wavelength axis is `NaN`-free — the fill interpolates *against* it, so a
  `NaN` there would poison every filled value rather than a single sample;
- the loaded struct is `NaN`-free — the fix actually fires;
- each filled value is bracketed by its two neighbours — this is what catches a
  *widened* gap, which a `NaN` count alone would not.

---

## Verification

- New tests: 4 passed.
- Full suite: **375 passed, 1 skipped** — no regressions.
- Original reproduction, `Vt = 20` and `25 km/s`: Ca now `n_SE` `NaN` = 0,
  `tau_1D` `NaN` = 0, `prof_1D` `NaN` = 0 (was 45, 19742, 19742). Also verified
  clean at `Vt = 40 km/s`, well past the threshold.
- `ruff check`, `ruff format --check`, `pyright`, and the pre-commit hooks pass.

## Scope

Two files, one behavioural change:

- `src/spectra/Struct/Radiation.py` — the load-time fill.
- `tests/regression/test_reg_Radiation.py` — new.

No solver, mesh, or atomic-data code is touched, and the atlas `.npy` is
unmodified.
